### PR TITLE
Configure mongo store using environment variables 

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,7 +19,9 @@ app.use(session({
 	proxy: true,
 	resave: true,
 	saveUninitialized: true,
-	store: new MongoStore({ host: 'localhost', port: 27017, db: 'suave'})
+	store: new MongoStore({ host: process.env.STOREHOST || 'localhost',
+		port: process.env.STOREPORT || 27017,
+		db: process.env.STOREDB || 'suave'})
 	})
 );
 

--- a/app/server/modules/account-manager.js
+++ b/app/server/modules/account-manager.js
@@ -7,9 +7,9 @@ var fsx = require('fs-extra');
 var fs = require('fs'); //file system
 var path = require('path');
 
-var dbPort 		= 27017;
-var dbHost 		= 'localhost';
-var dbName 		= 'suave';
+var dbPort 		= process.env.STOREPORT || 27017;
+var dbHost 		= process.env.STOREHOST || 'localhost';
+var dbName 		= process.env.STOREDB || 'suave';
 
 
 /* establish the database connection */

--- a/app/server/modules/annotation-manager.js
+++ b/app/server/modules/annotation-manager.js
@@ -10,9 +10,9 @@ var loader = require('./collection-loader');
 var GL = require('../global');
 
 
-var dbPort 		= 27017;
-var dbHost 		= 'localhost';
-var dbName 		= 'suave';
+var dbPort 		= process.env.STOREPORT || 27017;
+var dbHost 		= process.env.STOREHOST || 'localhost';
+var dbName 		= process.env.STOREDB || 'suave';
 
 
 /* establish the database connection */

--- a/app/server/modules/survey-manager.js
+++ b/app/server/modules/survey-manager.js
@@ -9,9 +9,9 @@ var loader = require('./collection-loader');
 var GL = require('../global');
 var AN = require('./annotation-manager');
 
-var dbPort 		= 27017;
-var dbHost 		= 'localhost';
-var dbName 		= 'suave';
+var dbPort 		= process.env.STOREPORT || 27017;
+var dbHost 		= process.env.STOREHOST || 'localhost';
+var dbName 		= process.env.STOREDB || 'suave';
 
 
 /* establish the database connection */


### PR DESCRIPTION
I am trying to dockerize SuAVE and it would be helpful to be able to specify the store host, port and db using environment variables so the node js app can be easily linked to mongo containers. 